### PR TITLE
Fedora downstream patches

### DIFF
--- a/module.mk
+++ b/module.mk
@@ -28,13 +28,13 @@ DRV_ONLY		?= 0
 
 
 # Flags
-CXXFLAGS		+= `cups-config --cflags` -Iinclude -Wall -I/opt/local/include
+CXXFLAGS		+= `pkg-config --cflags cups` -Iinclude -Wall -I/opt/local/include
 DEBUG_CXXFLAGS		+= -DDEBUG  -DDUMP_CACHE
 OPTIM_CXXFLAGS 		+= -g
-rastertoqpdl_LDFLAGS	:= $(LDFLAGS) `cups-config --ldflags` -L/opt/local/lib
-rastertoqpdl_LIBS	:= `cups-config --libs` -lcupsimage
-pstoqpdl_LDFLAGS	:= $(LDFLAGS) `cups-config --ldflags`
-pstoqpdl_LIBS		:= `cups-config --libs` -lcupsimage
+rastertoqpdl_LDFLAGS	:= $(LDFLAGS) -L/opt/local/lib
+rastertoqpdl_LIBS	:= `pkg-config --libs cups` -lcupsimage
+pstoqpdl_LDFLAGS	:= $(LDFLAGS)
+pstoqpdl_LIBS		:= `pkg-config --libs cups` -lcupsimage
 
 
 # Update compilation flags with defined options
@@ -56,16 +56,16 @@ endif
 
 
 # Get some information
-CUPSFILTER		:= `cups-config --serverbin`/filter
-CUPSPPD			?= `cups-config --datadir`/model
-CUPSDRV			?= `cups-config --datadir`/drv
+CUPSFILTER		:= `pkg-config --variable=cups_serverbin cups`/filter
+CUPSPPD			?= `pkg-config --variable=cups_datadir cups`/model
+CUPSDRV			?= `pkg-config --variable=cups_datadir cups`/drv
 ifeq ($(ARCHI),Darwin)
 PSTORASTER		:= pstocupsraster
 else
 PSTORASTER		:= pstoraster
 endif
 GSTORASTER		:= gstoraster
-CUPSPROFILE			:= `cups-config --datadir`/profiles
+CUPSPROFILE			:= `pkg-config --variable=cups_datadir`/profiles
 export CUPSFILTER CUPSPPD CUPSDRV
 
 

--- a/module.mk
+++ b/module.mk
@@ -31,9 +31,9 @@ DRV_ONLY		?= 0
 CXXFLAGS		+= `cups-config --cflags` -Iinclude -Wall -I/opt/local/include
 DEBUG_CXXFLAGS		+= -DDEBUG  -DDUMP_CACHE
 OPTIM_CXXFLAGS 		+= -g
-rastertoqpdl_LDFLAGS	:= `cups-config --ldflags` -L/opt/local/lib
+rastertoqpdl_LDFLAGS	:= $(LDFLAGS) `cups-config --ldflags` -L/opt/local/lib
 rastertoqpdl_LIBS	:= `cups-config --libs` -lcupsimage
-pstoqpdl_LDFLAGS	:= `cups-config --ldflags`
+pstoqpdl_LDFLAGS	:= $(LDFLAGS) `cups-config --ldflags`
 pstoqpdl_LIBS		:= `cups-config --libs` -lcupsimage
 
 

--- a/ppd/samsung.drv.in
+++ b/ppd/samsung.drv.in
@@ -39,6 +39,7 @@ Manufacturer "Samsung"
             Resolution k 1 0 0 0 "300dpi/300 DPI"
  
             ModelName "SCX-4200"
+            Attribute "1284DeviceID" "" "MFG:Samsung;MDL:SCX-4200 Series;CMD:GDI;"
             PCFileName "scx4200.ppd"
         } {
             Resolution k 1 0 0 0 "300dpi/300 DPI"
@@ -83,6 +84,7 @@ Manufacturer "Samsung"
                     PCFileName "ml1520.ppd"
                 } {
                     ModelName "ML-1610"
+                    Attribute "1284DeviceID" "" "MFG:Samsung;MDL:ML-1610;CMD:GDI;"
                     PCFileName "ml1610.ppd"
                 } {
                     ModelName "ML-1710"
@@ -121,6 +123,7 @@ Manufacturer "Samsung"
                     Throughput 22
     		{
                     	ModelName "ML-2250"
+                    	Attribute "1284DeviceID" "" "MFG:Samsung;MDL:ML-2250;"
     	                PCFileName "ml2250.ppd"
     		} {
                     	ModelName "ML-2251"
@@ -163,9 +166,11 @@ Manufacturer "Samsung"
                     PCFileName "ml1630.ppd"
                 } {
                     ModelName "ML-1640"
+                    Attribute "1284DeviceID" "" "MFG:Samsung;MDL:ML-1640 Series;CMD:GDI,FWV;"
                     PCFileName "ml1640.ppd"
                 } {
                     ModelName "ML-2010"
+                    Attribute "1284DeviceID" "" "MFG:Samsung;MDL:ML-2010;CMD:GDI;"
                     PCFileName "ml2010.ppd"
                 } {
                     ModelName "ML-2015"
@@ -177,6 +182,7 @@ Manufacturer "Samsung"
                     #import "srtmode.defs"
     
                     ModelName "ML-2510"
+                    Attribute "1284DeviceID" "" "MFG:Samsung;MDL:ML-2510 Series;CMD:GDI;"
                     PCFileName "ml2510.ppd"
                 }
             }
@@ -193,15 +199,18 @@ Manufacturer "Samsung"
     
                 {
                     ModelName "ML-1660"
+                    Attribute "1284DeviceID" "" "MFG:Samsung;MDL:ML-1660 Series;CMD:GDI,FWV,EXT;"
                     PCFileName "ml1660.ppd"
                 } {
                     ModelName "ML-1910"
                     PCFileName "ml1910.ppd"
                 } {
                     ModelName "ML-2525"
+                    Attribute "1284DeviceID" "" "MFG:Samsung;MDL:ML-2525 Series;CMD:GDI,FWV,EXT;"
                     PCFileName "ml2525.ppd"
                 } {
                     ModelName "ML-2525W"
+                    Attribute "1284DeviceID" "" "MFG:Samsung;MDL:ML-2525W Series;CMD:GDI,FWV,EXT;"
                     PCFileName "ml2525w.ppd"
                 }
             } {
@@ -239,6 +248,7 @@ Manufacturer "Samsung"
                 Attribute QPDL PacketSize "512"
                 {
                     ModelName "ML-2160"
+                    Attribute "1284DeviceID" "" "MFG:Samsung;MDL:ML-2160 Series;CMD:SPL,FWV,PIC,BDN,EXT;"
                     PCFileName "ml2160.ppd"
 	        }
             }
@@ -465,6 +475,7 @@ Manufacturer "Samsung"
         Attribute General CMSFile "CLP-310"
 
         ModelName "CLP-310"
+        Attribute "1284DeviceID" "" "MFG:Samsung;MDL:CLP-310 Series;CMD:SPLC,FWV;"
         PCFileName "clp310.ppd"
     }{
         Attribute General CMSFile "CLP-315"

--- a/ppd/xerox.drv.in
+++ b/ppd/xerox.drv.in
@@ -31,6 +31,7 @@ Manufacturer "Xerox"
 	    Resolution k 1 0 0 0 "300dpi/300 DPI"
 
             ModelName "WorkCentre 3119"
+            Attribute "1284DeviceID" "" "MFG:Xerox;MDL:WorkCentre 3119 Series;CMD:GDI;"
             PCFileName "wc3119.ppd"
 	} {
             Resolution k 1 0 0 0 "300dpi/300 DPI"
@@ -66,6 +67,7 @@ Manufacturer "Xerox"
                 } {
                     #import "manualduplex.defs"
                     ModelName "Phaser 3120"
+                    Attribute "1284DeviceID" "" "MFG:Xerox;MDL:Phaser 3120;CMD:GDI;"
                     PCFileName "ph3120.ppd"
                 } {
                     #import "manualduplex.defs"
@@ -74,6 +76,7 @@ Manufacturer "Xerox"
                 } {
                     #import "manualduplex.defs"
                     ModelName "Phaser 3130"
+                    Attribute "1284DeviceID" "" "MFG:Xerox;MDL:Phaser 3130;CMD:PCL5E,PCL6;"
                     PCFileName "ph3130.ppd"
                 } {
                     // Multi-tray
@@ -118,6 +121,7 @@ Manufacturer "Xerox"
 
             {
                 ModelName "Phaser 3117"
+                Attribute "1284DeviceID" "" "MFG:Xerox;MDL:Phaser 3117;CMD:GDI;"
                 PCFileName "ph3117.ppd"
             } {
                 Resolution k 1 0 0 0 "1200x600dpi/1200x600 DPI"
@@ -131,6 +135,7 @@ Manufacturer "Xerox"
 
                 {
                     ModelName "Phaser 3124"
+                    Attribute "1284DeviceID" "" "MFG:Xerox;MDL:Phaser 3124;CMD:GDI;"
                     PCFileName "ph3124.ppd"
                 }
             }


### PR DESCRIPTION
Hi,

I saw the announcement on the OpenPrinting News, so when I was rebasing the package, I found out several downstream patches which can be handy for others.

They are split into three commits:

1. Add DeviceIDs into PPD files, which were gathered from users and they were missing in the original PPDs - helps system-config-printer to find the best driver available, but it can have other uses as well,
2. Update modules.mk to accept build system LDFLAGS - useful if the distro has specific flags which need to be used when linking the project,
3. Switch splix to pkg-config instead of cups-config - the cups-config tool is deprecated for several years and will be removed in the next major CUPS release, and its replacement is available with CUPS 2.4.x series, so we can use that from now.

Do you think they are useful to be merged? Do let me know if I should update something.


Zdenek