### PR TITLE
Add support for manual duplex on Samsung SCX-4521F

### DIFF
--- a/ppd/samsung.drv.in
+++ b/ppd/samsung.drv.in
@@ -27,6 +27,7 @@ Manufacturer "Samsung"
     // Monochrome printers V. 1 (old algorithms)
     {
         #import "monochrome-v1.defs"
+        #import "manualduplex.defs"
         Attribute QPDL QPDLVersion "1"
         Attribute General DocHeaderValues "<0><2><1>"
         


### PR DESCRIPTION
Haven't tested it on other models mentioned in this section.